### PR TITLE
Add cohort analysis for red meat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Consumption YSSP
+
+This repository processes Global Dietary Database (GDD) data. Raw GDD CSV files are not tracked in Git. The cleaning pipeline combines these files into `data/processed/gdd_cleaned_panel.csv`.
+
+## Scripts
+
+- `scripts/clean_data.py` – cleans the raw GDD country files into a single panel.
+- `scripts/analyze_red_meat.py` – analyzes cohort-based Red meat intake across education levels.
+
+## Cohort-Based Red Meat Analysis
+
+Run the analysis after generating the cleaned panel:
+
+```bash
+python scripts/analyze_red_meat.py
+```
+
+The script will create `data/processed/red_meat_cohort_education.csv` with mean intake by birth cohort (decades) and education level.

--- a/scripts/analyze_red_meat.py
+++ b/scripts/analyze_red_meat.py
@@ -1,0 +1,34 @@
+import pandas as pd
+from pathlib import Path
+
+DATA_FILE = Path('data/processed/gdd_cleaned_panel.csv')
+OUT_FILE = Path('data/processed/red_meat_cohort_education.csv')
+
+
+def main():
+    if not DATA_FILE.exists():
+        raise FileNotFoundError(f"{DATA_FILE} not found. Please run clean_data.py first.")
+
+    df = pd.read_csv(DATA_FILE)
+    df = df[df['food'] == 'Red meat'].copy()
+    df = df.dropna(subset=['age', 'year', 'education', 'value'])
+
+    df['birth_year'] = df['year'] - df['age']
+    df['cohort'] = (df['birth_year'] // 10) * 10
+
+    summary = (
+        df.groupby(['cohort', 'education'])['value']
+        .mean()
+        .reset_index()
+        .rename(columns={'value': 'mean_intake'})
+        .sort_values(['cohort', 'education'])
+    )
+
+    OUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    summary.to_csv(OUT_FILE, index=False)
+    print(summary.head())
+    print(f"\n✅ Cohort analysis saved to {OUT_FILE.resolve()}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a README describing the repository and analysis steps
- add `analyze_red_meat.py` to compute cohort-based red meat intake by education level

## Testing
- `python -m py_compile scripts/analyze_red_meat.py`
- `python -m py_compile scripts/clean_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6840ae5c425083328418b49216853a7d